### PR TITLE
Fix reference to file to run

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ To run this example, clone the repository or copy the code from `example.py`, an
 
 ```
 export SLACK_API_TOKEN=”<YOUR SLACK BOT TOKEN>” 
-python link-buttoms.py
+python example.py
 ```
 
 Need help? Find us in the [Bot Developer Hangout](http://dev4slack.xoxco.com/) [#slack-api channel](https://dev4slack.slack.com/messages/slack-api/), reach out on [Twitter](https://twitter.com/slackapi), or [create an issue](https://github.com/slackapi/python-link-button-example/issues) on GitHub.


### PR DESCRIPTION
No file named link-buttoms.py (meant link-buttons.py?).
So either rename the file from example.py, or update the docs.